### PR TITLE
Keep globe stationary during hover expansion

### DIFF
--- a/BarWidget.qml
+++ b/BarWidget.qml
@@ -93,7 +93,12 @@ BarWidget {
     id: button
     anchors.fill: parent
     bar: root.bar
-    text: root.expanded ? root.icon + "   " + root.compact : root.icon
+    // Keep WidgetButton as the interaction surface, but draw the icon and
+    // expanding label separately so centering a longer string cannot move the
+    // icon. The button grows only to the right of the icon's fixed position.
+    text: " "
+    fixedWidth: labelRow.implicitWidth + scaledHorizontalMargin * 2
+    foreground: "transparent"
     tooltipText: ""
 
     onPressed: function(b) {
@@ -101,6 +106,33 @@ BarWidget {
       if (b === Qt.RightButton) root.bar.run("omarchy-launch-browser " + Util.shellQuote(root.wtbUrl))
       else if (b === Qt.MiddleButton) root.refresh()
       else root.togglePanel()
+    }
+  }
+
+  Row {
+    id: labelRow
+    anchors.left: button.left
+    anchors.leftMargin: button.scaledHorizontalMargin
+    anchors.verticalCenter: button.verticalCenter
+    spacing: root.expanded ? Style.space(8) : 0
+
+    Text {
+      text: root.icon
+      textFormat: Text.PlainText
+      color: button.active && button.useActiveColor ? button.activeColor : (root.bar ? root.bar.barForeground : Color.foreground)
+      font.family: button.fontFamily
+      font.pixelSize: button.fontSize
+      renderType: Text.NativeRendering
+    }
+
+    Text {
+      visible: root.expanded
+      text: root.compact
+      textFormat: Text.PlainText
+      color: button.active && button.useActiveColor ? button.activeColor : (root.bar ? root.bar.barForeground : Color.foreground)
+      font.family: button.fontFamily
+      font.pixelSize: button.fontSize
+      renderType: Text.NativeRendering
     }
   }
 }


### PR DESCRIPTION
## Summary

- render the globe and compact timezone label as separate text elements
- keep the globe in a fixed leading position while the label expands to its right
- preserve the existing hover expansion setting and click behavior

## Why

The previous implementation centered the globe and compact label as one changing string. When the label appeared on hover, recentering the longer string subtly shifted the globe left. Separating the visual elements keeps the icon stationary while retaining the useful hover details.

## Testing

- loaded the modified plugin in a live Omarchy shell
- verified the shell restarted successfully
- manually confirmed the globe remains stationary during hover expansion and the interaction feels correct