### PR TITLE
Keep the globe still when the hover pill expands

### DIFF
--- a/BarWidget.qml
+++ b/BarWidget.qml
@@ -21,7 +21,17 @@ BarWidget {
   readonly property bool hoverExpand: setting("hoverExpand", true) === true
 
   readonly property string compact: panelLoader.item ? panelLoader.item.compactLabel : ""
-  readonly property bool expanded: hoverExpand && !vertical && button.tooltipHovered && compact !== ""
+
+  // Hover is tracked on the whole pill, not just the icon button: once the
+  // times are out, the pointer is free to travel across them without the
+  // pill collapsing out from under it.
+  readonly property bool pillHovered: button.tooltipHovered || pillHover.hovered
+  readonly property bool expanded: hoverExpand && !vertical && pillHovered && compact !== ""
+
+  // Gap between the icon button and the times, and the padding that keeps the
+  // times off the next widget — the button only pads its own glyph.
+  readonly property real revealLeadIn: Style.spaceReal(10)
+  readonly property real revealTrail: button.scaledHorizontalMargin
 
   function injectPanel() {
     var target = panelLoader.item
@@ -38,6 +48,13 @@ BarWidget {
 
   function togglePanel() {
     if (panelLoader.item && panelLoader.item.toggle) panelLoader.item.toggle()
+  }
+
+  function handlePress(b) {
+    if (!root.bar) return
+    if (b === Qt.RightButton) root.bar.run("omarchy-launch-browser " + Util.shellQuote(root.wtbUrl))
+    else if (b === Qt.MiddleButton) root.refresh()
+    else root.togglePanel()
   }
 
   // Shape contract for shell.summon/hide/toggle routing (Bar.findPanelWidget
@@ -61,7 +78,7 @@ BarWidget {
     if (panelLoader.item) panelLoader.item.closeForPopoutSwitch()
   }
 
-  implicitWidth: button.implicitWidth
+  implicitWidth: button.implicitWidth + reveal.width
   implicitHeight: button.implicitHeight
 
   onBarChanged: injectPanel()
@@ -89,18 +106,66 @@ BarWidget {
     function refresh(): void { root.refresh() }
   }
 
+  HoverHandler { id: pillHover }
+
+  // The button carries the glyph alone and never changes size. Folding the
+  // times into its label instead re-centers the label on every hover, and
+  // since the slack a centered label leaves depends on the string being
+  // measured, the globe visibly jumps sideways as the times appear.
   WidgetButton {
     id: button
-    anchors.fill: parent
+    anchors.left: parent.left
+    anchors.top: parent.top
+    anchors.bottom: parent.bottom
+    width: button.implicitWidth
     bar: root.bar
-    text: root.expanded ? root.icon + "   " + root.compact : root.icon
+    text: root.icon
     tooltipText: ""
 
-    onPressed: function(b) {
-      if (!root.bar) return
-      if (b === Qt.RightButton) root.bar.run("omarchy-launch-browser " + Util.shellQuote(root.wtbUrl))
-      else if (b === Qt.MiddleButton) root.refresh()
-      else root.togglePanel()
+    onPressed: function(b) { root.handlePress(b) }
+  }
+
+  // The times wipe out from behind the globe rather than appearing at full
+  // width, so the widgets downstream of the pill slide instead of jumping.
+  Item {
+    id: reveal
+    anchors.left: button.right
+    anchors.verticalCenter: button.verticalCenter
+    height: button.height
+    visible: !root.vertical
+    clip: true
+
+    width: root.expanded ? root.revealLeadIn + times.implicitWidth + root.revealTrail : 0
+
+    Behavior on width {
+      NumberAnimation { duration: 160; easing.type: Easing.OutCubic }
+    }
+
+    Text {
+      id: times
+      x: root.revealLeadIn
+      anchors.verticalCenter: parent.verticalCenter
+      text: root.compact
+      textFormat: Text.PlainText
+      color: root.bar ? root.bar.barForeground : Color.foreground
+      font.family: root.bar ? root.bar.fontFamily : Style.font.family
+      font.pixelSize: Style.font.body
+      renderType: Text.NativeRendering
+      opacity: root.expanded ? 1 : 0
+
+      Behavior on opacity {
+        NumberAnimation { duration: 160; easing.type: Easing.OutCubic }
+      }
+    }
+
+    // The revealed times stayed clickable when they were part of the button's
+    // label; keep them so.
+    MouseArea {
+      anchors.fill: parent
+      acceptedButtons: Qt.LeftButton | Qt.RightButton | Qt.MiddleButton
+      hoverEnabled: true
+      cursorShape: Qt.PointingHandCursor
+      onClicked: function(mouse) { root.handlePress(mouse.button) }
     }
   }
 }


### PR DESCRIPTION
## The problem

Hovering the globe makes it twitch sideways before the times appear. It is small, but it happens on every hover and it happens under the pointer, so it reads as jank rather than as motion.

`BarWidget.qml` swaps the button's label between `icon` and `icon + "   " + compact`. `WidgetButton` centers that label in its slot, and the slack a centered label leaves over its own painted ink depends on which string was measured — so the globe's ink lands in a different place in each state even though the widget's left edge never moves.

Measured on a 2x display, sampling the globe glyph's ink columns from a screenshot of the bar, with the widgets to its left held constant:

| state | globe ink (device px) |
| --- | --- |
| collapsed | 123–142 |
| expanded | 120–139 |

A consistent 3 device px / 1.5 logical px jump left, reproducible on every hover.

## The fix

Give the glyph its own fixed-width `WidgetButton` and move the times into a sibling strip anchored to its right. The button's label is now always just the icon, so its layout never changes and the globe cannot move:

| state | globe ink (device px) |
| --- | --- |
| collapsed | 123–142 |
| expanded | 123–142 |

Two things fall out of the split:

- **The reveal can animate.** The strip clips its text and animates its width (160ms `OutCubic`, matching the shell's own `Behavior` durations), so the times wipe out from behind the globe and the widgets downstream of the pill slide to their new positions instead of jumping there in one frame. The text fades in over the same interval.
- **Hover is tracked on the whole pill** via a `HoverHandler` on the widget root, not on the button alone. Otherwise the pointer moving onto the revealed times would leave the (now icon-sized) button and collapse the pill. The revealed times also keep the click behaviour they had while they were part of the button's label.

`hoverExpand: false` is untouched and still collapses this to a static icon; the vertical bar still gets the icon-only button with no strip.

The lead-in between the globe and the times is `spaceReal(10)` plus the button's own right margin, which lands within a pixel of the three-space gap it replaces, so the pill looks the same once expanded.

## Testing

Ran against Omarchy's shell on a 2x display, in the center section with `centerAnchor: omarchy.clock`. Verified: the globe's ink columns are identical collapsed and expanded; the strip animates through intermediate widths rather than snapping; hovering across the revealed times keeps the pill open; clicking the times still toggles the panel.