### PR TITLE
Add a 12-hour mode, and a right-click that toggles it

### DIFF
--- a/BarWidget.qml
+++ b/BarWidget.qml
@@ -21,7 +21,17 @@ BarWidget {
   readonly property bool hoverExpand: setting("hoverExpand", true) === true
 
   readonly property string compact: panelLoader.item ? panelLoader.item.compactLabel : ""
-  readonly property bool expanded: hoverExpand && !vertical && button.tooltipHovered && compact !== ""
+
+  // Hover is tracked on the whole pill, not just the icon button: once the
+  // times are out, the pointer is free to travel across them without the
+  // pill collapsing out from under it.
+  readonly property bool pillHovered: button.tooltipHovered || pillHover.hovered
+  readonly property bool expanded: hoverExpand && !vertical && pillHovered && compact !== ""
+
+  // Gap between the icon button and the times, and the padding that keeps the
+  // times off the next widget — the button only pads its own glyph.
+  readonly property real revealLeadIn: Style.spaceReal(10)
+  readonly property real revealTrail: button.scaledHorizontalMargin
 
   function injectPanel() {
     var target = panelLoader.item
@@ -38,6 +48,13 @@ BarWidget {
 
   function togglePanel() {
     if (panelLoader.item && panelLoader.item.toggle) panelLoader.item.toggle()
+  }
+
+  function handlePress(b) {
+    if (!root.bar) return
+    if (b === Qt.RightButton) root.bar.run("omarchy-launch-browser " + Util.shellQuote(root.wtbUrl))
+    else if (b === Qt.MiddleButton) root.refresh()
+    else root.togglePanel()
   }
 
   // Shape contract for shell.summon/hide/toggle routing (Bar.findPanelWidget
@@ -61,7 +78,7 @@ BarWidget {
     if (panelLoader.item) panelLoader.item.closeForPopoutSwitch()
   }
 
-  implicitWidth: button.implicitWidth
+  implicitWidth: button.implicitWidth + reveal.width
   implicitHeight: button.implicitHeight
 
   onBarChanged: injectPanel()
@@ -89,18 +106,66 @@ BarWidget {
     function refresh(): void { root.refresh() }
   }
 
+  HoverHandler { id: pillHover }
+
+  // The button carries the glyph alone and never changes size. Folding the
+  // times into its label instead re-centers the label on every hover, and
+  // since the slack a centered label leaves depends on the string being
+  // measured, the globe visibly jumps sideways as the times appear.
   WidgetButton {
     id: button
-    anchors.fill: parent
+    anchors.left: parent.left
+    anchors.top: parent.top
+    anchors.bottom: parent.bottom
+    width: button.implicitWidth
     bar: root.bar
-    text: root.expanded ? root.icon + "   " + root.compact : root.icon
+    text: root.icon
     tooltipText: ""
 
-    onPressed: function(b) {
-      if (!root.bar) return
-      if (b === Qt.RightButton) root.bar.run("omarchy-launch-browser " + Util.shellQuote(root.wtbUrl))
-      else if (b === Qt.MiddleButton) root.refresh()
-      else root.togglePanel()
+    onPressed: function(b) { root.handlePress(b) }
+  }
+
+  // The times wipe out from behind the globe rather than appearing at full
+  // width, so the widgets downstream of the pill slide instead of jumping.
+  Item {
+    id: reveal
+    anchors.left: button.right
+    anchors.verticalCenter: button.verticalCenter
+    height: button.height
+    visible: !root.vertical
+    clip: true
+
+    width: root.expanded ? root.revealLeadIn + times.implicitWidth + root.revealTrail : 0
+
+    Behavior on width {
+      NumberAnimation { duration: 160; easing.type: Easing.OutCubic }
+    }
+
+    Text {
+      id: times
+      x: root.revealLeadIn
+      anchors.verticalCenter: parent.verticalCenter
+      text: root.compact
+      textFormat: Text.PlainText
+      color: root.bar ? root.bar.barForeground : Color.foreground
+      font.family: root.bar ? root.bar.fontFamily : Style.font.family
+      font.pixelSize: Style.font.body
+      renderType: Text.NativeRendering
+      opacity: root.expanded ? 1 : 0
+
+      Behavior on opacity {
+        NumberAnimation { duration: 160; easing.type: Easing.OutCubic }
+      }
+    }
+
+    // The revealed times stayed clickable when they were part of the button's
+    // label; keep them so.
+    MouseArea {
+      anchors.fill: parent
+      acceptedButtons: Qt.LeftButton | Qt.RightButton | Qt.MiddleButton
+      hoverEnabled: true
+      cursorShape: Qt.PointingHandCursor
+      onClicked: function(mouse) { root.handlePress(mouse.button) }
     }
   }
 }

--- a/BarWidget.qml
+++ b/BarWidget.qml
@@ -20,6 +20,10 @@ BarWidget {
   // wants.
   readonly property bool hoverExpand: setting("hoverExpand", true) === true
 
+  // What the right button does: open worldtimebuddy (the default) or flip the
+  // widget between 24-hour and AM/PM.
+  readonly property string rightClick: String(setting("rightClick", "worldtimebuddy"))
+
   readonly property string compact: panelLoader.item ? panelLoader.item.compactLabel : ""
 
   // Hover is tracked on the whole pill, not just the icon button: once the
@@ -50,9 +54,24 @@ BarWidget {
     if (panelLoader.item && panelLoader.item.toggle) panelLoader.item.toggle()
   }
 
+  // A bar surface exists per monitor, so flip every instance — otherwise the
+  // format would change on one screen and not the others.
+  function toggleHourFormat() {
+    broadcast("toggleHourFormatHere")
+  }
+
+  function toggleHourFormatHere() {
+    if (panelLoader.item && panelLoader.item.toggleHourFormat) panelLoader.item.toggleHourFormat()
+  }
+
+  function runRightClick() {
+    if (root.rightClick === "toggleHourFormat") root.toggleHourFormat()
+    else root.bar.run("omarchy-launch-browser " + Util.shellQuote(root.wtbUrl))
+  }
+
   function handlePress(b) {
     if (!root.bar) return
-    if (b === Qt.RightButton) root.bar.run("omarchy-launch-browser " + Util.shellQuote(root.wtbUrl))
+    if (b === Qt.RightButton) root.runRightClick()
     else if (b === Qt.MiddleButton) root.refresh()
     else root.togglePanel()
   }
@@ -104,6 +123,7 @@ BarWidget {
     function hide(): void { root.close() }
     function toggle(): void { root.togglePanel() }
     function refresh(): void { root.refresh() }
+    function toggleHourFormat(): void { root.toggleHourFormat() }
   }
 
   HoverHandler { id: pillHover }

--- a/Model.js
+++ b/Model.js
@@ -75,10 +75,24 @@ function pad2(n) {
   return (n < 10 ? "0" : "") + n
 }
 
-// "07:12" for a zone right now.
-function timeLabel(nowUtcMs, offsetMin) {
+// 0 → 12, 13 → 1: the hour as a 12-hour clock reads it.
+function hour12(hour) {
+  var h = hour % 12
+  return h === 0 ? 12 : h
+}
+
+// "07:12" for a zone right now, or "7:12 AM" in 12-hour mode.
+function timeLabel(nowUtcMs, offsetMin, use12Hour) {
   var f = localFields(nowUtcMs, offsetMin)
-  return pad2(f.hour) + ":" + pad2(f.minute)
+  if (!use12Hour) return pad2(f.hour) + ":" + pad2(f.minute)
+  return hour12(f.hour) + ":" + pad2(f.minute) + (f.hour < 12 ? " AM" : " PM")
+}
+
+// One grid cell's hour. The 12-hour form stays as short as worldtimebuddy's
+// ("1p", "11a") because a cell is only wide enough for three characters.
+function hourLabel(hour, use12Hour) {
+  if (!use12Hour) return String(hour)
+  return hour12(hour) + (hour < 12 ? "a" : "p")
 }
 
 // "Thu 21 Aug" style date for the row header.
@@ -105,12 +119,12 @@ function nowColumn(nowUtcMs, dayStartUtcMs) {
 }
 
 // Compact bar label shown on hover: "NY 07:12 · SF 04:12 · CDO 19:12".
-function compactLabel(zones, nowUtcMs) {
+function compactLabel(zones, nowUtcMs, use12Hour) {
   var parts = []
   for (var i = 0; i < zones.length; i++) {
     var z = zones[i]
     if (z.home || z.offsetMin === undefined || z.offsetMin === null) continue
-    parts.push(plainText(z.shortLabel) + " " + timeLabel(nowUtcMs, z.offsetMin))
+    parts.push(plainText(z.shortLabel) + " " + timeLabel(nowUtcMs, z.offsetMin, use12Hour))
   }
   return parts.join(" · ")
 }
@@ -134,7 +148,9 @@ if (typeof module !== "undefined") {
     localFields: localFields,
     cell: cell,
     tintFor: tintFor,
+    hour12: hour12,
     timeLabel: timeLabel,
+    hourLabel: hourLabel,
     dateLabel: dateLabel,
     diffLabel: diffLabel,
     nowColumn: nowColumn,

--- a/Panel.qml
+++ b/Panel.qml
@@ -67,6 +67,16 @@ Panel {
   property var offsets: ({})
   property string systemTz: ""
 
+  // 12-hour vs 24-hour. Seeded from the "hourFormat" setting and then owned
+  // by the widget, so a right-click toggle can flip it for the session
+  // without a shell.json edit.
+  readonly property bool configured12Hour: String(setting("hourFormat", "24h")).toLowerCase() === "12h"
+  property bool use12Hour: configured12Hour
+
+  function toggleHourFormat() {
+    use12Hour = !use12Hour
+  }
+
   readonly property var zoneConfig: setting("zones", Model.defaultZones())
   // System timezones that keep the configured home label. Outside this list
   // (or with none configured) the home row is labeled by where the system
@@ -112,7 +122,7 @@ Panel {
   property int hoverCol: -1
 
   // What the bar pill shows on hover.
-  readonly property string compactLabel: ready ? Model.compactLabel(zones, nowUtc) : ""
+  readonly property string compactLabel: ready ? Model.compactLabel(zones, nowUtc, use12Hour) : ""
 
   // ---- Grid geometry.
   readonly property real cellW: Style.space(27)
@@ -244,8 +254,8 @@ Panel {
                 Text {
                   text: !zoneItem.rowReady ? "—"
                     : root.hoverCol >= 0
-                      ? Model.timeLabel(root.dayStart + root.hoverCol * 3600000, zoneItem.zoneRow.offsetMin)
-                      : Model.timeLabel(root.nowUtc, zoneItem.zoneRow.offsetMin)
+                      ? Model.timeLabel(root.dayStart + root.hoverCol * 3600000, zoneItem.zoneRow.offsetMin, root.use12Hour)
+                      : Model.timeLabel(root.nowUtc, zoneItem.zoneRow.offsetMin, root.use12Hour)
                   color: root.hoverCol >= 0 ? Color.accent : root.fg
                   font.family: root.fontFam
                   font.pixelSize: Style.font.body
@@ -292,7 +302,7 @@ Panel {
                     anchors.centerIn: parent
                     horizontalAlignment: Text.AlignHCenter
                     lineHeight: 0.85
-                    text: c.isMidnight ? c.dayLabel.replace(" ", "\n") : String(c.hour)
+                    text: c.isMidnight ? c.dayLabel.replace(" ", "\n") : Model.hourLabel(c.hour, root.use12Hour)
                     color: c.isMidnight ? root.fg
                          : c.tint === "night" ? Qt.darker(root.fg, 1.6)
                          : root.fg

--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ omarchy plugin add https://github.com/sspaeti/omarchy-timezones-plugin.git --ena
 - **Left click**: open/close the hour-grid popup (Escape also closes)
 - **Hover a column** in the popup: converts that moment across all zones
 - **Middle click**: refresh timezone offsets
-- **Right click**: open worldtimebuddy.com in the browser
+- **Right click**: open worldtimebuddy.com in the browser, or toggle 24-hour
+  vs AM/PM — see `rightClick` below
 
 ## Configure
 
@@ -79,6 +80,12 @@ To pick your own zones and labels, configure the widget entry in
   expanding to the compact times on hover (the expansion shifts neighboring
   widgets, which not everyone wants). Default `true`.
 - `worldtimebuddyUrl` — right-click target.
+- `hourFormat` — `"24h"` (default) or `"12h"`. Sets how the bar's hover view,
+  the popup's row times, and the hour grid read the clock.
+- `rightClick` — what the right button does: `"worldtimebuddy"` (default)
+  opens `worldtimebuddyUrl`, `"toggleHourFormat"` flips between 24-hour and
+  AM/PM instead. The toggle lasts for the session; `hourFormat` decides where
+  it starts.
 
 Move it in the bar:
 


### PR DESCRIPTION
> Stacked on #3 — the first commit here is that PR's fix, so the diff will shrink to a single commit once #3 lands (or can be rebased onto whatever you prefer). Entirely fine to take one, both, or neither.

## Why

The widget speaks 24-hour time only, which is the wrong dialect in exactly the places a world clock earns its keep. Reading `NY 17:30` to work out whether it is a reasonable hour to call someone means converting twice — once across zones, once across notations.

## What

**`hourFormat`** — `"24h"` (default, unchanged) or `"12h"`. One setting read by all three surfaces, so they never disagree:

- bar hover label — `NY 12:46 PM · SF 9:46 AM`
- popup row times — `12:46 PM +1h`
- the hour grid — `1a 2a … 12p 1p …`, worldtimebuddy's own compact form, which matters because a cell is only wide enough for three characters

**`rightClick`** — `"worldtimebuddy"` (default, unchanged) or `"toggleHourFormat"`. The format is the kind of thing you want flipped for a single glance and then want back, which is a poor fit for a config edit and a good fit for the button that is currently spending itself on a browser launch. Users who prefer the browser launch keep it by doing nothing.

The toggle is session state seeded from `hourFormat`, and it goes through `broadcast()` so every bar surface flips together — otherwise a multi-monitor setup ends up reading two different clocks. It is exposed on the IPC target as `toggleHourFormat` as well, so it can be bound to a key.

`Model.js` gets `hour12`, `hourLabel`, and an optional `use12Hour` argument on `timeLabel`/`compactLabel`; omitting the argument keeps the existing 24-hour output, so nothing else in the module changes shape.

## Testing

Ran against Omarchy's shell on a 2x display. Verified both formats in the bar label and in the popup (row headers and the full 24-column grid, including the midnight day-label cells), that toggling flips back and forth cleanly, and that the 12-hour grid labels still fit their cells. `hourFormat` unset plus `rightClick` unset reproduces today's behaviour exactly.